### PR TITLE
fix: fix typos

### DIFF
--- a/leccion-08-metodo-constructor/README.md
+++ b/leccion-08-metodo-constructor/README.md
@@ -38,11 +38,11 @@ Agreguémosle una propiedad a `DiceWrapper` llamada `sides` que será del tipo `
 
 ### 2. Adaptar la función `value`
 
-En la lección anterior habíamos programado nuestro `DiceWrapper` para que tirase al azar un número entre 1 y 6 y lo guardará en `value`. Ahora lo vamos a adaptar a será entre 1 y el número de lados usando la palabra clave `this`.
+En la lección anterior habíamos programado nuestro `DiceWrapper` para que tirase al azar un número entre 1 y 6 y lo guardará en `value`. Ahora lo vamos a adaptar para que acepte entre 1 y el número de lados dados, usando la palabra clave `this`.
 
 ### Crédito extra: Propiedad privada
 
-En clases de TypeScript, podemos tener propiedades públicas y privadas usando las palabras claves `public` y `private. Volvámos a nuestro ejemplo de la clase `Perro`:
+En clases de TypeScript, podemos tener propiedades públicas y privadas usando las palabras claves `public` y `private`. Volvámos a nuestro ejemplo de la clase `Perro`:
 
 ```typescript
 class Perro {

--- a/leccion-09-herencia/README.md
+++ b/leccion-09-herencia/README.md
@@ -115,7 +115,7 @@ También verás que cambió el constructor y el `value`, además agregamos `dieF
 En esta lección, vamos a agregar una clase abstracta llamada `Die` y sus subclases:
 
 - OneDie
-- TwiDie
+- TwoDie
 - ThreeDie
 - FourDie
 - FiveDie

--- a/leccion-10-guardias-de-tipos/README.md
+++ b/leccion-10-guardias-de-tipos/README.md
@@ -86,7 +86,7 @@ throw new Error(message);
 
 ¡Pongámos nuestra nueva propiedad opcional en práctica!
 
-Cambiemos la firma de nuestra función `dieForValue` en la línea 15:
+Cambiemos la firma de nuestra función `dieForValue` en la línea 18:
 
 ```typescript
   private dieForValue(value: number): Die | undefined {


### PR DESCRIPTION
### Changes
- Fix: changes typos in README.md files in lessons 8, 9, and 10

### Testing
- checked in my local environment

### Docs
- N/A